### PR TITLE
fix: keep dropdown open when dragging list scrollbar (closes #3)

### DIFF
--- a/BlazorBootstrapCustomControls/Components/Shared/BlazorBootstrapSelectMarkup.razor
+++ b/BlazorBootstrapCustomControls/Components/Shared/BlazorBootstrapSelectMarkup.razor
@@ -30,7 +30,9 @@
 
   @if (Open)
   {
-    <div class="bs-select-dropdown @(DropdownMatchInputWidth ? "bs-select-dropdown-match-input" : "")" role="listbox">
+    @* mousedown preventDefault: keeps focus on combobox input when using scrollbar (issue #3); blur would otherwise close the list. *@
+    <div class="bs-select-dropdown @(DropdownMatchInputWidth ? "bs-select-dropdown-match-input" : "")" role="listbox"
+         @onmousedown:preventDefault="true">
       @foreach (var (item, i) in Items.Select((x, idx) => (x, idx)))
       {
         var ii = i;

--- a/BlazorBootstrapCustomControls/wwwroot/js/bootstrap-select.js
+++ b/BlazorBootstrapCustomControls/wwwroot/js/bootstrap-select.js
@@ -13,6 +13,7 @@
  * - Tab: closes list and allows natural focus movement
  * - Delete (when list closed): clears selection when clear button is shown
  * - Input blur: closes list (label, other controls, tab, etc.)
+ * - Dropdown panel mousedown: default prevented in markup so scrollbar drag does not blur the input (issue #3)
  */
 
 (function () {
@@ -36,7 +37,7 @@
   window.BSSelect = {
     /**
      * Initialize component (reserved for future use).
-     * List closes on input blur (handled in Blazor); no click-outside JS.
+     * List closes on input blur (handled in Blazor); scrollbar interaction uses mousedown preventDefault on the panel.
      * @param {string} componentId - Unique component instance ID
      * @param {DotNetObjectReference} dotNetRef - Reference to Blazor component
      */

--- a/BlazorBootstrapCustomControlsApp/Pages/BlazorBootstrapSelect.razor
+++ b/BlazorBootstrapCustomControlsApp/Pages/BlazorBootstrapSelect.razor
@@ -11,8 +11,9 @@
 <h4 class="mt-4">Single Select (BlazorBootstrapSelectSingle)</h4>
 <p class="text-muted small">Input-like single-select control with @@bind-Value support and keyboard navigation.</p>
 
-<BlazorBootstrapSelectSingleString Label="Single Sport (Custom, DropdownMatchInputWidth=true)"
-                                   Data="@Sports"
+<p class="text-muted small">Many options below exercise the dropdown scrollbar; drag the thumb — the list should stay open (see <a href="https://github.com/miesch1/BlazorBootstrapCustomControls/issues/3">issue #3</a>).</p>
+<BlazorBootstrapSelectSingleString Label="Single Sport (Custom, DropdownMatchInputWidth=true — many options / scrollbar)"
+                                   Data="@SportsMany"
                                    PlaceholderText="-- Select Sport --"
                                    DropdownMatchInputWidth="true"
                                    @bind-Value="@selectedSportCustom" />
@@ -155,6 +156,16 @@
     "Basketball",
     "Soccer",
     "Tennis"
+  };
+
+  /// <summary>Enough entries to exceed .bs-select-dropdown max-height (~17.5rem) for scrollbar drag testing (issue #3).</summary>
+  private static readonly List<string> SportsMany = new()
+  {
+    "Archery", "Badminton", "Baseball", "Basketball", "Bowling", "Boxing", "Cheerleading", "Cricket",
+    "Cross-Country", "Cycling", "Diving", "Equestrian", "Fencing", "Field Hockey", "Football", "Golf",
+    "Gymnastics", "Ice Hockey", "Lacrosse", "Martial Arts", "Rowing", "Rugby", "Sailing", "Skateboarding",
+    "Skiing", "Soccer", "Softball", "Swimming", "Table Tennis", "Tennis", "Track & Field", "Volleyball",
+    "Water Polo", "Weightlifting", "Wrestling"
   };
 
   private List<SportOption> SportOptions = new()

--- a/docs/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
+++ b/docs/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
@@ -13,6 +13,7 @@
  * - Tab: closes list and allows natural focus movement
  * - Delete (when list closed): clears selection when clear button is shown
  * - Input blur: closes list (label, other controls, tab, etc.)
+ * - Dropdown panel mousedown: default prevented in markup so scrollbar drag does not blur the input (issue #3)
  */
 
 (function () {
@@ -36,7 +37,7 @@
   window.BSSelect = {
     /**
      * Initialize component (reserved for future use).
-     * List closes on input blur (handled in Blazor); no click-outside JS.
+     * List closes on input blur (handled in Blazor); scrollbar interaction uses mousedown preventDefault on the panel.
      * @param {string} componentId - Unique component instance ID
      * @param {DotNetObjectReference} dotNetRef - Reference to Blazor component
      */

--- a/docs/wwwroot/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
+++ b/docs/wwwroot/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
@@ -12,6 +12,7 @@
  * - Escape: closes list
  * - Tab: closes list and allows natural focus movement
  * - Input blur: closes list (label, other controls, tab, etc.)
+ * - Dropdown panel mousedown: default prevented in markup so scrollbar drag does not blur the input (issue #3)
  */
 
 (function () {
@@ -35,7 +36,7 @@
   window.BSSelect = {
     /**
      * Initialize component (reserved for future use).
-     * List closes on input blur (handled in Blazor); no click-outside JS.
+     * List closes on input blur (handled in Blazor); scrollbar interaction uses mousedown preventDefault on the panel.
      * @param {string} componentId - Unique component instance ID
      * @param {DotNetObjectReference} dotNetRef - Reference to Blazor component
      */


### PR DESCRIPTION
- Prevent default mousedown on .bs-select-dropdown so the combobox input does not blur when interacting with the native scrollbar.
- Demo: first single-select uses SportsMany (~35 items) to force overflow.
- Sync JS header comments in docs static copies.

Made-with: Cursor