### PR TITLE
fix(select): harden BSSelect keyboard wiring for interactive render

### DIFF
--- a/BlazorBootstrapCustomControls/Components/Shared/BlazorBootstrapSelectBase.cs
+++ b/BlazorBootstrapCustomControls/Components/Shared/BlazorBootstrapSelectBase.cs
@@ -34,6 +34,8 @@ public abstract class BlazorBootstrapSelectBase<TItem, TValue> : ComponentBase, 
   /// Used to skip JS teardown in <see cref="DisposeAsync"/> when prerender/SSR disposes the tree before interop is allowed (issue #7).
   /// </summary>
   private bool _bssSelectJsRegistered;
+  private byte _bssSelectRegisterAttempts;
+  private const byte MaxBssSelectRegisterAttempts = 32;
 
   /// <summary>Snapshot of <see cref="Data"/> built in <see cref="OnParametersSet"/> (avoids reallocating on every access).</summary>
   protected IReadOnlyList<SelectItem<TItem, TValue>> _items = Array.Empty<SelectItem<TItem, TValue>>();
@@ -363,11 +365,15 @@ public abstract class BlazorBootstrapSelectBase<TItem, TValue> : ComponentBase, 
   {
     // Prerender / static SSR: not interactive — skip JS (same InvalidOperationException as dispose if invoked).
     // After prerender, the component renders again with an interactive RendererInfo; init then (even if firstRender is false).
-    if (!_bssSelectJsRegistered && RendererInfo.IsInteractive)
+    if (!_bssSelectJsRegistered && RendererInfo.IsInteractive
+        && _bssSelectRegisterAttempts < MaxBssSelectRegisterAttempts)
     {
       await JS.InvokeVoidAsync("BSSelect.init", _id, _dotNetRef);
-      await JS.InvokeVoidAsync("BSSelect.registerInputKeys", _id, _dotNetRef);
-      _bssSelectJsRegistered = true;
+      var keysRegistered = await JS.InvokeAsync<bool>("BSSelect.registerInputKeys", _id, _dotNetRef);
+      if (keysRegistered)
+        _bssSelectJsRegistered = true;
+      else
+        _bssSelectRegisterAttempts++;
     }
 
     if (_bssSelectJsRegistered && _open && _justOpened)

--- a/BlazorBootstrapCustomControls/wwwroot/css/bootstrap-select.css
+++ b/BlazorBootstrapCustomControls/wwwroot/css/bootstrap-select.css
@@ -292,7 +292,7 @@
 /* Optional semantic chip used by default rendering when SemanticField is provided. */
 .status-chip {
   display: inline-block;
-  margin-left: 0.5rem;
+  /* Spacing from label/icon: parent uses flex gap (e.g. .gap-2); avoid extra margin or text–chip looks wider than icon–text */
   padding: 0.1rem 0.5rem;
   border-radius: 9999px;
   font-size: 0.75em;

--- a/BlazorBootstrapCustomControls/wwwroot/js/bootstrap-select.js
+++ b/BlazorBootstrapCustomControls/wwwroot/js/bootstrap-select.js
@@ -74,7 +74,17 @@
     registerInputKeys: function (componentId, dotNetRef) {
       var r = root(componentId);
       var inp = r?.querySelector('.bs-select-input');
-      if (!inp) return;
+      if (!inp) return false;
+
+      // Idempotent: if this component was already wired (e.g. re-run on same DOM node),
+      // remove the previous listeners before attaching. Otherwise keydown runs twice per
+      // physical key — extra arrow steps, broken type-ahead buffer, double Enter toggles.
+      var prev = handlers[componentId];
+      if (prev && prev.inputKey) {
+        inp.removeEventListener('keydown', prev.inputKey);
+        if (prev.compStart) inp.removeEventListener('compositionstart', prev.compStart);
+        if (prev.compEnd) inp.removeEventListener('compositionend', prev.compEnd);
+      }
 
       var composing = false;
       function onCompStart() { composing = true; }
@@ -101,6 +111,13 @@
         } else {
           var ariaExpanded = inp.getAttribute('aria-expanded');
           isOpen = ariaExpanded && ariaExpanded.toLowerCase() === 'true';
+        }
+
+        // Key-repeat on Enter would invoke HandleListKey twice (multi-select: select then undo).
+        if (isOpen && k === 'Enter' && e.repeat) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
         }
 
         if (!isOpen && k === 'Delete' && r.querySelector('.bs-select-clear')) {
@@ -144,6 +161,7 @@
       handlers[componentId].inputKey = h;
       handlers[componentId].compStart = onCompStart;
       handlers[componentId].compEnd = onCompEnd;
+      return true;
     }
   };
 })();

--- a/docs/_content/BlazorBootstrapCustomControls/css/bootstrap-select.css
+++ b/docs/_content/BlazorBootstrapCustomControls/css/bootstrap-select.css
@@ -292,7 +292,7 @@
 /* Optional semantic chip used by default rendering when SemanticField is provided. */
 .status-chip {
   display: inline-block;
-  margin-left: 0.5rem;
+  /* Spacing from label/icon: parent uses flex gap (e.g. .gap-2); avoid extra margin or text–chip looks wider than icon–text */
   padding: 0.1rem 0.5rem;
   border-radius: 9999px;
   font-size: 0.75em;

--- a/docs/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
+++ b/docs/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
@@ -74,7 +74,17 @@
     registerInputKeys: function (componentId, dotNetRef) {
       var r = root(componentId);
       var inp = r?.querySelector('.bs-select-input');
-      if (!inp) return;
+      if (!inp) return false;
+
+      // Idempotent: if this component was already wired (e.g. re-run on same DOM node),
+      // remove the previous listeners before attaching. Otherwise keydown runs twice per
+      // physical key — extra arrow steps, broken type-ahead buffer, double Enter toggles.
+      var prev = handlers[componentId];
+      if (prev && prev.inputKey) {
+        inp.removeEventListener('keydown', prev.inputKey);
+        if (prev.compStart) inp.removeEventListener('compositionstart', prev.compStart);
+        if (prev.compEnd) inp.removeEventListener('compositionend', prev.compEnd);
+      }
 
       var composing = false;
       function onCompStart() { composing = true; }
@@ -101,6 +111,13 @@
         } else {
           var ariaExpanded = inp.getAttribute('aria-expanded');
           isOpen = ariaExpanded && ariaExpanded.toLowerCase() === 'true';
+        }
+
+        // Key-repeat on Enter would invoke HandleListKey twice (multi-select: select then undo).
+        if (isOpen && k === 'Enter' && e.repeat) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
         }
 
         if (!isOpen && k === 'Delete' && r.querySelector('.bs-select-clear')) {
@@ -144,6 +161,7 @@
       handlers[componentId].inputKey = h;
       handlers[componentId].compStart = onCompStart;
       handlers[componentId].compEnd = onCompEnd;
+      return true;
     }
   };
 })();

--- a/docs/wwwroot/_content/BlazorBootstrapCustomControls/css/bootstrap-select.css
+++ b/docs/wwwroot/_content/BlazorBootstrapCustomControls/css/bootstrap-select.css
@@ -292,7 +292,7 @@
 /* Optional semantic chip used by default rendering when SemanticField is provided. */
 .status-chip {
   display: inline-block;
-  margin-left: 0.5rem;
+  /* Spacing from label/icon: parent uses flex gap (e.g. .gap-2); avoid extra margin or text–chip looks wider than icon–text */
   padding: 0.1rem 0.5rem;
   border-radius: 9999px;
   font-size: 0.75em;

--- a/docs/wwwroot/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
+++ b/docs/wwwroot/_content/BlazorBootstrapCustomControls/js/bootstrap-select.js
@@ -74,7 +74,17 @@
     registerInputKeys: function (componentId, dotNetRef) {
       var r = root(componentId);
       var inp = r?.querySelector('.bs-select-input');
-      if (!inp) return;
+      if (!inp) return false;
+
+      // Idempotent: if this component was already wired (e.g. re-run on same DOM node),
+      // remove the previous listeners before attaching. Otherwise keydown runs twice per
+      // physical key — extra arrow steps, broken type-ahead buffer, double Enter toggles.
+      var prev = handlers[componentId];
+      if (prev && prev.inputKey) {
+        inp.removeEventListener('keydown', prev.inputKey);
+        if (prev.compStart) inp.removeEventListener('compositionstart', prev.compStart);
+        if (prev.compEnd) inp.removeEventListener('compositionend', prev.compEnd);
+      }
 
       var composing = false;
       function onCompStart() { composing = true; }
@@ -101,6 +111,13 @@
         } else {
           var ariaExpanded = inp.getAttribute('aria-expanded');
           isOpen = ariaExpanded && ariaExpanded.toLowerCase() === 'true';
+        }
+
+        // Key-repeat on Enter would invoke HandleListKey twice (multi-select: select then undo).
+        if (isOpen && k === 'Enter' && e.repeat) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
         }
 
         if (!isOpen && k === 'Delete' && r.querySelector('.bs-select-clear')) {
@@ -144,6 +161,7 @@
       handlers[componentId].inputKey = h;
       handlers[componentId].compStart = onCompStart;
       handlers[componentId].compEnd = onCompEnd;
+      return true;
     }
   };
 })();


### PR DESCRIPTION
- Make registerInputKeys idempotent: remove prior keydown/composition listeners on the same input before attaching, avoiding duplicate HandleListKey / type-ahead invocations per physical keypress.
- Ignore key-repeat for Enter while the list is open to prevent double-toggle on multi-select.
- Have registerInputKeys return whether .bs-select-input was found; set _bssSelectJsRegistered only on success and retry up to a cap so prerender/BWA timing cannot mark registration complete too early.

Sync the same JS updates under docs _content paths.